### PR TITLE
ci: Pin the bundler version in GitHub Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         FIRST_NAME: ${{ secrets.CODECOV_TOKEN }}
       run: |
         yarn install --check-files
-        gem install bundler
+        gem install bundler -v 2.4.21
         bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
         bundle exec rails db:create


### PR DESCRIPTION
In the CI Workflow, the version for bundler has been explicitly specified to 2.4.21. This change ensures consistency across development and production environments, addressing potential version discrepancy issues.

ℹ️ Blocker for https://github.com/eliflores/railsgirls/pull/52