### PR TITLE
chore: Add Bundler version to .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 ruby 2.7.2
+bundler 2.4.21


### PR DESCRIPTION
This change specifies the Bundler version to use within the project. Keeping consistent tool versions helps to prevent issues that might arise from inconsistencies between environments.